### PR TITLE
Fixed two Group GETS being the same url

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -325,11 +325,11 @@ router.get('/', (req, res) => {
 });
 
 //Get all groups of which username is a member
-router.get('/:username', (req, res) => {
+router.get('/user/:username', (req, res) => {
     Group.findAll({
         where: {
             admin: req.params.username,
-            members : { $contains : req.params.username }
+            members : { $contains : [req.params.username] }
         }
     }).then(result => {
         if(result.length !== 0) {


### PR DESCRIPTION
GET groups for user now = base/group/user/:username
GET group by id now = base/group/:group_id